### PR TITLE
Add a link to an eternal website

### DIFF
--- a/src/vue-mermaid.vue
+++ b/src/vue-mermaid.vue
@@ -171,6 +171,13 @@ export default {
             return `click ${item.id} mermaidClick`;
           })
           .join("\n") +
+        "\n" +
+        nodes
+          .filter(item => item.url)
+          .map(item => {
+            return `click ${item.id} "${item.url}"`;
+          })
+          .join("\n") +
         "\n"
       );
     },


### PR DESCRIPTION
I added the ability to add a link to an eternal website for the node.(Issue #16)

[mermaid support](https://mermaid-js.github.io/mermaid/#/flowchart?id=interaction) this ability as below: 
`click B "http://www.github.com" "This is a link"`

To implement this ability, I add the "url" key to data properties.